### PR TITLE
Preserve trailing /fhir on fhir server endpoints

### DIFF
--- a/backend/routes/fhir/proxy.ts
+++ b/backend/routes/fhir/proxy.ts
@@ -49,7 +49,7 @@ export default async function proxy(req: Request, res: Response) {
     }
 
     // Proxy ---------------------------------------------------------------
-    const response = await fetch(new URL(req.url, fhirServer + "").href, fhirRequestOptions);
+    const response = await fetch(new URL(fhirServer + req.url).href, fhirRequestOptions);
 
     res.status(response.status);
 


### PR DESCRIPTION
Preserve trailing "/fhir" pathnames in FHIR server endpoint urls.
The code was truncating them previously, resulting in FHIR REST API requests to fail 