### PR TITLE
Add support for discovering associated_endpoints

### DIFF
--- a/backend/config.ts
+++ b/backend/config.ts
@@ -60,5 +60,11 @@ export default {
     /**
      * Our private key as PEM (used to generate the JWKS at /keys)
      */
-    privateKeyAsPem: FS.readFileSync(__dirname + "/../private-key.pem", "utf8")
+    privateKeyAsPem: FS.readFileSync(__dirname + "/../private-key.pem", "utf8"),
+
+    /**
+     * Associated endpoints for imaging, etc
+     */
+    associatedEndpoints: JSON.parse(env.ASSOCIATED_ENDPOINTS || "[]")
+
 }

--- a/backend/routes/fhir/.well-known/smart-configuration.ts
+++ b/backend/routes/fhir/.well-known/smart-configuration.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express"
 import { getRequestBaseURL } from "../../../lib"
-
+import config from "../../../config"; 
 
 export default function getWellKnownSmartConfig(req: Request, res: Response) {
     
@@ -173,7 +173,8 @@ export default function getWellKnownSmartConfig(req: Request, res: Response) {
 
             // support for POST-based authorization
             "authorize-post"
-        ]
+        ],
+        associated_endpoints: config?.associatedEndpoints?.length ? config.associatedEndpoints : undefined
     };
 
     res.json(json);


### PR DESCRIPTION
In support of Argonuat Imaging project -- proposed new field in the discovery document. See [this example](https://github.com/sync-for-science/imaging#:~:text=The%20discovery%20document%20at%20https%3A//ehr.example.org/fhir/.well%2Dknown/smart%2Dconfiguration%20would%20include%3A) for intended use.