### PR TITLE
Add support for including fhirContext

### DIFF
--- a/backend/routes/auth/authorize.ts
+++ b/backend/routes/auth/authorize.ts
@@ -333,6 +333,7 @@ export default class AuthorizeHandler {
             context: {
                 need_patient_banner: !launchOptions.sim_ehr,
                 smart_style_url: this.baseUrl + "/smart-style.json",
+                fhirContext: launchOptions.fhirContextStr ? JSON.parse(launchOptions.fhirContextStr) : undefined
             },
             client_id   : params.client_id,
             redirect_uri: params.redirect_uri + "",

--- a/backend/routes/launcher.ts
+++ b/backend/routes/launcher.ts
@@ -13,6 +13,7 @@ export default (req: Request, res: Response) => {
         provider,
         sim_ehr,
         select_encounter,
+        fhirContextStr
     } = req.query;
     
     // launch_uri --------------------------------------------------------------
@@ -52,6 +53,7 @@ export default (req: Request, res: Response) => {
         encounter  : bool(select_encounter) ? "MANUAL" : "AUTO",
         pkce       : "auto",
         client_type: "public",
+        fhirContextStr: String(fhirContextStr || "")
     })
 
     url.searchParams.set("launch", launchOptions.toString())

--- a/index.d.ts
+++ b/index.d.ts
@@ -69,6 +69,7 @@ declare namespace SMART {
         jwks?: string
         pkce?: PKCEValidation
         client_type?: SMARTClientType
+        fhirContextStr?: string
     }
 
     interface AuthorizeParams {
@@ -335,7 +336,7 @@ declare namespace SMART {
          * “Patient” or “Encounter”. It is not prohibited to have more than one
          * Reference to a given type of resource.
          */
-        fhirContext?: string[]
+        fhirContext?: Record<string, string>[]
 
         /**
          * Simulated error to throw

--- a/src/components/Launcher/index.tsx
+++ b/src/components/Launcher/index.tsx
@@ -87,6 +87,12 @@ function getValidationErrors(launch: SMART.LaunchParams, query: LauncherQuery) {
         }
     }
 
+    try {
+        JSON.parse(launch.fhirContextStr || "null")
+    } catch {
+        validationErrors.push("Invalid fhirContext JSON")
+    }
+
     return validationErrors
 }
 
@@ -102,21 +108,22 @@ export default function Launcher() {
     const launchCode = encode({
         ...DEFAULT_LAUNCH_PARAMS,
         launch_type,
-        patient      : launch.patient,
-        provider     : launch.provider,
-        encounter    : launch.encounter,
-        skip_login   : launch.skip_login,
-        skip_auth    : launch.skip_auth,
+        patient       : launch.patient,
+        provider      : launch.provider,
+        encounter     : launch.encounter,
+        skip_login    : launch.skip_login,
+        skip_auth     : launch.skip_auth,
         sim_ehr,
-        scope        : launch.scope,
-        redirect_uris: launch.redirect_uris,
-        client_id    : launch.client_id,
-        client_secret: launch.client_secret,
-        auth_error   : launch.auth_error,
-        jwks_url     : launch.jwks_url,
-        jwks         : launch.jwks,
-        client_type  : launch.client_type,
-        pkce         : launch.pkce
+        scope         : launch.scope,
+        redirect_uris : launch.redirect_uris,
+        client_id     : launch.client_id,
+        client_secret : launch.client_secret,
+        auth_error    : launch.auth_error,
+        jwks_url      : launch.jwks_url,
+        jwks          : launch.jwks,
+        client_type   : launch.client_type,
+        pkce          : launch.pkce,
+        fhirContextStr: launch.fhirContextStr
     })
 
     const isStandaloneLaunch = launch_type.includes("standalone");
@@ -491,6 +498,20 @@ function LaunchTab() {
                         </span>
                     </div>
                 </div> : null }
+            <div className="col-sm-6">
+                <div className="form-group">
+                    <label htmlFor="fhirContext" className="text-primary"><code>fhirContext</code></label>
+                        <input
+                            type="text"
+                            className="form-control"
+                            id="fhirContext"
+                            name="fhirContext"
+                            value={ launch.fhirContextStr }
+                            onChange={ e => setQuery({ fhirContextStr: e.target.value }) }
+                        />
+                        <span className="help-block small">Additional references to FHIR resources to include along with the access token</span>
+                </div>
+            </div>
         </div>
     )
 }

--- a/src/components/SampleApp/TokenResponse.tsx
+++ b/src/components/SampleApp/TokenResponse.tsx
@@ -9,6 +9,7 @@ import {
     renderString,
     renderUrl
 } from "../../lib"
+import Clip from "../Clip";
 
 
 const KNOWN_PROPS = {
@@ -65,6 +66,11 @@ const KNOWN_PROPS = {
         type: "string",
         render: (s: any) => renderString(s, 80),
         desc: <>The ID token (if any).</>
+    },
+    fhirContext: {
+        type: "string",
+        render: (s: any) => <code><Clip txt={ JSON.stringify(s) } /></code>,
+        desc: <>References to additional FHIR resources (if any)</>
     },
 }
 

--- a/src/isomorphic/LaunchOptions.ts
+++ b/src/isomorphic/LaunchOptions.ts
@@ -66,6 +66,7 @@ export default class LaunchOptions
 
     pkce: SMART.PKCEValidation;
 
+    fhirContextStr?: string;
     
     constructor(input: string | SMART.LaunchParams)
     {
@@ -73,20 +74,21 @@ export default class LaunchOptions
             input = codec.decode(input)
         }
 
-        this.launch_type   = input.launch_type
-        this.skip_login    = input.skip_login === true
-        this.skip_auth     = input.skip_auth  === true
-        this.sim_ehr       = input.sim_ehr    === true
-        this.auth_error    = input.auth_error
-        this.client_secret = input.client_secret || ""
-        this.encounter     = input.encounter     || ""
-        this.scope         = input.scope         || ""
-        this.redirect_uris = input.redirect_uris || ""
-        this.client_id     = input.client_id     || ""
-        this.jwks_url      = input.jwks_url      || ""
-        this.jwks          = input.jwks          || ""
-        this.client_type   = input.client_type   || "public"
-        this.pkce          = input.pkce          || "auto"
+        this.launch_type      = input.launch_type
+        this.skip_login       = input.skip_login === true
+        this.skip_auth        = input.skip_auth  === true
+        this.sim_ehr          = input.sim_ehr    === true
+        this.auth_error       = input.auth_error
+        this.client_secret    = input.client_secret || ""
+        this.encounter        = input.encounter     || ""
+        this.scope            = input.scope         || ""
+        this.redirect_uris    = input.redirect_uris || ""
+        this.client_id        = input.client_id     || ""
+        this.jwks_url         = input.jwks_url      || ""
+        this.jwks             = input.jwks          || ""
+        this.client_type      = input.client_type   || "public"
+        this.pkce             = input.pkce          || "auto"
+        this.fhirContextStr   = input.fhirContextStr
         this.provider.set(input.provider || "");
         this.patient.set(input.patient  || "");
     }
@@ -99,22 +101,23 @@ export default class LaunchOptions
     public toJSON(): SMART.LaunchParams
     {
         return {
-            launch_type  : this.launch_type,
-            patient      : this.patient.toString(),
-            provider     : this.provider.toString(),
-            encounter    : this.encounter,
-            skip_login   : this.skip_login,
-            skip_auth    : this.skip_auth,
-            sim_ehr      : this.sim_ehr,
-            scope        : this.scope,
-            redirect_uris: this.redirect_uris,
-            client_id    : this.client_id,
-            client_secret: this.client_secret,
-            auth_error   : this.auth_error,
-            jwks_url     : this.jwks_url,
-            jwks         : this.jwks,
-            client_type  : this.client_type,
-            pkce         : this.pkce
+            launch_type     : this.launch_type,
+            patient         : this.patient.toString(),
+            provider        : this.provider.toString(),
+            encounter       : this.encounter,
+            skip_login      : this.skip_login,
+            skip_auth       : this.skip_auth,
+            sim_ehr         : this.sim_ehr,
+            scope           : this.scope,
+            redirect_uris   : this.redirect_uris,
+            client_id       : this.client_id,
+            client_secret   : this.client_secret,
+            auth_error      : this.auth_error,
+            jwks_url        : this.jwks_url,
+            jwks            : this.jwks,
+            client_type     : this.client_type,
+            pkce            : this.pkce,
+            fhirContextStr  : this.fhirContextStr
         }
     }
 }

--- a/src/isomorphic/codec.ts
+++ b/src/isomorphic/codec.ts
@@ -64,7 +64,8 @@ export function encode(params: SMART.LaunchParams, ignoreErrors = false): string
             params.jwks_url      || "",
             params.jwks          || "",
             clientTypes.indexOf(params.client_type || "public"),
-            PKCEValidationTypes.indexOf(params.pkce || "auto")
+            PKCEValidationTypes.indexOf(params.pkce || "auto"),
+            params.fhirContextStr
         ]))
     }
 
@@ -84,7 +85,8 @@ export function encode(params: SMART.LaunchParams, ignoreErrors = false): string
         params.jwks_url      || "",
         params.jwks          || "",
         clientTypes.indexOf(params.client_type || "public"),
-        PKCEValidationTypes.indexOf(params.pkce || "auto")
+        PKCEValidationTypes.indexOf(params.pkce || "auto"),
+        params.fhirContextStr
     ];
 
     return base64UrlEncode(JSON.stringify(arr))
@@ -109,22 +111,23 @@ export function decode(launch: string): SMART.LaunchParams {
     }
 
     return {
-        launch_type  : launchType,
-        patient      : arr[1 ] || "",
-        provider     : arr[2 ] || "",
-        encounter    : arr[3 ] || "",
-        skip_login   : arr[4 ] === 1,
-        skip_auth    : arr[5 ] === 1,
-        sim_ehr      : arr[6 ] === 1,
-        scope        : arr[7 ] || "",
-        redirect_uris: arr[8 ] || "",
-        client_id    : arr[9 ] || "",
-        client_secret: arr[10] || "",
-        auth_error   : arr[11] || "",
-        jwks_url     : arr[12] || "",
-        jwks         : arr[13] || "",
-        client_type  : clientTypes[arr[14]],
-        pkce         : PKCEValidationTypes[arr[15]]
+        launch_type     : launchType,
+        patient         : arr[1 ] || "",
+        provider        : arr[2 ] || "",
+        encounter       : arr[3 ] || "",
+        skip_login      : arr[4 ] === 1,
+        skip_auth       : arr[5 ] === 1,
+        sim_ehr         : arr[6 ] === 1,
+        scope           : arr[7 ] || "",
+        redirect_uris   : arr[8 ] || "",
+        client_id       : arr[9 ] || "",
+        client_secret   : arr[10] || "",
+        auth_error      : arr[11] || "",
+        jwks_url        : arr[12] || "",
+        jwks            : arr[13] || "",
+        client_type     : clientTypes[arr[14]],
+        pkce            : PKCEValidationTypes[arr[15]],
+        fhirContextStr  : arr[16] || undefined
     }
 }
 


### PR DESCRIPTION
Adds a new input for including `fhirContext`[[1]](https://build.fhir.org/ig/HL7/smart-app-launch/scopes-and-launch-context.html#fhir-context) in the JWT token. 

I initially did the work for some internal testing, but am happy to merge it upstream if it's wanted.