### PR TITLE
Fix aud verification when proxy disabled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,9 @@ USER node
 WORKDIR /home/node
 COPY package*.json ./
 COPY --chown=node . .
-RUN npm ci --production=false
+RUN npm ci
 RUN npm run build
+RUN npm ci --omit=dev
 
 # Final Image
 FROM node:18 AS final
@@ -14,10 +15,10 @@ WORKDIR /app
 ENV NODE_ENV "production"
 ENV PORT "80"
 COPY package*.json ./
-RUN npm ci --production=true
 COPY backend ./backend
 COPY src/isomorphic ./src/isomorphic
 COPY *.pem ./
 COPY --from=build /home/node/build ./build
+COPY --from=build /home/node/node_modules ./node_modules
 EXPOSE 80
 CMD ["/app/node_modules/.bin/ts-node", "--skipProject", "--transpile-only", "./backend/index.ts"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,65 @@
+pipeline {
+  agent any
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '10'))
+  }
+  environment {
+    AWS_CREDENTIALS = credentials('AWS-KEYS')
+    AWS_ENV = """${sh(
+      returnStdout: true,
+      script: 'env | awk -F= \'/^AWS/ {print "-e " $1}\''
+    )}"""
+    GIT_ENV = """${sh(
+      returnStdout: true,
+      script: 'env | awk -F= \'/^GIT/ {print "-e " $1}\''
+    )}"""
+  }
+  stages {
+    stage('Setup') {
+      steps {
+        sh '''
+          docker pull $CICD_ECR_REGISTRY/cicd:latest
+          docker tag $CICD_ECR_REGISTRY/cicd:latest cicd:latest
+        '''
+      }
+    }
+    stage('Build') {
+      steps {
+        echo 'Building Docker Image'
+        sh "docker build -t smart-launcher-v2 -f Dockerfile ."
+      }
+    }
+    stage('Push') {
+      steps {
+        echo 'Pushing Docker Image'
+        sh 'docker run -v /var/run/docker.sock:/var/run/docker.sock $AWS_ENV $GIT_ENV cicd push smart-launcher-v2'
+      }
+    }
+    // stage('Deploy') {
+    //   steps {
+    //     echo 'Deploying to internal'
+    //     sh 'docker run -v /var/run/docker.sock:/var/run/docker.sock $AWS_ENV $GIT_ENV cicd deploy smart-launcher-v2 internal $GIT_COMMIT'
+    //   }
+    // }
+    // stage('Wait') {
+    //   steps {
+    //     echo 'Waiting for service to reach steady state'
+    //     sh 'docker run -v /var/run/docker.sock:/var/run/docker.sock $AWS_ENV cicd wait smart-launcher-v2 internal'
+    //   }
+    // }
+    // stage('Healthcheck') {
+    //   steps {
+    //     echo 'Checking health of service'
+    //     sh 'curl -m 10 https://smart-launcher-v2-internal.elimuinformatics.com/'
+    //   }
+    // }
+  }
+  post {
+    unsuccessful {
+      slackSend color: 'danger', channel: '#product-ops-stage', message: "Pipeline Failed: ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)"
+    }
+    fixed {
+      slackSend color: 'good', channel: '#product-ops-stage', message: "Pipeline Ran Successfully: ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)"
+    }
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
     buildDiscarder(logRotator(numToKeepStr: '10'))
   }
   environment {
+    AWS_ACCOUNTS = '435911253355'
     AWS_CREDENTIALS = credentials('AWS-KEYS')
     AWS_ENV = """${sh(
       returnStdout: true,

--- a/README.md
+++ b/README.md
@@ -65,6 +65,6 @@ docker run -t -p 8080:80 smartonfhir/smart-launcher-2:latest
 and open http://localhost:8080
 
 <!--
-docker build -t smartonfhir/smart-launcher:latest .
-docker push smartonfhir/smart-launcher:latest
+docker build -t smartonfhir/smart-launcher-2:latest .
+docker push smartonfhir/smart-launcher-2:latest
 -->

--- a/backend/config.ts
+++ b/backend/config.ts
@@ -60,5 +60,11 @@ export default {
     /**
      * Our private key as PEM (used to generate the JWKS at /keys)
      */
-    privateKeyAsPem: FS.readFileSync(__dirname + "/../private-key.pem", "utf8")
-}
+    privateKeyAsPem: FS.readFileSync(__dirname + "/../private-key.pem", "utf8"),
+
+    /**
+     * Proxy requests to the FHIR server. Defaults to true. Can be disabled 
+     * if the FHIR server has its own .well-known/smart-configuration
+     */
+    proxyFhirRequests: env.PROXY_FHIR_REQUESTS !== "false",
+};

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -75,7 +75,8 @@ app.use("/env.js", (_, res) => {
         FHIR_SERVER_R4     : config.fhirServerR4,
         ACCESS_TOKEN       : jwt.sign({ client_id: "launcherUI" }, config.jwtSecret, { expiresIn: "10 years" }),
         VERSION            : pkg.version,
-        COMMIT             : process.env.SOURCE_VERSION
+        COMMIT             : process.env.SOURCE_VERSION,
+        PROXY_FHIR_REQUESTS: process.env.PROXY_FHIR_REQUESTS !== "false",
     };
 
     res.type("application/javascript").send(`var ENV = ${JSON.stringify(out, null, 4)};`);

--- a/backend/lib.ts
+++ b/backend/lib.ts
@@ -44,7 +44,7 @@ export function notSupported(message: string = "", code = 400) {
     };
 }
 
-export function getFhirServerBaseUrl(req: Request) {
+export function getFhirServerBaseUrl(req: { params: { fhir_release: string }}) {
     const fhirVersion = req.params.fhir_release.toUpperCase();
     let fhirServer = config[`fhirServer${fhirVersion}` as keyof typeof config] as string;
 

--- a/backend/lib.ts
+++ b/backend/lib.ts
@@ -2,7 +2,7 @@ import jwt from "jsonwebtoken"
 import { NextFunction, Request, Response, RequestHandler } from "express"
 import config from "./config";
 import { HttpError, InvalidRequestError } from "./errors";
-
+import { SMART } from "..";
 
 /**
  * Given a request object, returns its base URL
@@ -44,7 +44,7 @@ export function notSupported(message: string = "", code = 400) {
     };
 }
 
-export function getFhirServerBaseUrl(req: { params: { fhir_release: string }}) {
+export function getFhirServerBaseUrl(req: Request | SMART.AuthorizeRequest) {
     const fhirVersion = req.params.fhir_release.toUpperCase();
     let fhirServer = config[`fhirServer${fhirVersion}` as keyof typeof config] as string;
 

--- a/backend/routes/auth/authorize.ts
+++ b/backend/routes/auth/authorize.ts
@@ -432,7 +432,9 @@ export default class AuthorizeHandler {
 
         // The "aud" param must match the apiUrl (but can have different protocol)
         // console.log(req.url, req.baseUrl)
-        const apiUrl = new URL(request.baseUrl.replace(/\/auth.*$/, "/fhir"), this.baseUrl)
+        const apiUrl = config.proxyFhirRequests
+          ? new URL(request.baseUrl.replace(/\/auth.*$/, "/fhir"), this.baseUrl)
+          : new URL(getFhirServerBaseUrl(request));
         const apiUrlHref = apiUrl.href
 
         let audUrl: URL        

--- a/example.env
+++ b/example.env
@@ -41,3 +41,6 @@ REFRESH_TOKEN_LIFETIME =
 
 # Comma-separated list of IPs that are not sllowed to access this service
 IP_BLACK_LIST = ""
+
+# Proxy requests to the FHIR server. Defaults to true. Can be disabled if the FHIR server has its own .well-known/smart-configuration
+PROXY_FHIR_REQUESTS = "true"

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,7 @@ declare global {
         ACCESS_TOKEN       : string
         VERSION            : string
         COMMIT             : string
+        PROXY_FHIR_REQUESTS: boolean
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "smart-launcher",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "smart-launcher",
-      "version": "2.0.0",
+      "version": "2.0.1",
+      "hasInstallScript": true,
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.3.0",
@@ -54,6 +55,9 @@
         "nyc": "^15.1.0",
         "selenium-webdriver": "^4.4.0",
         "ts-mocha": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/src/components/Launcher/index.tsx
+++ b/src/components/Launcher/index.tsx
@@ -131,7 +131,9 @@ export default function Launcher() {
     const aud = `${backendOrigin}/v/${fhir_version}/sim/${launchCode}/fhir`;
 
     // FHIR baseUrl for EHR launches
-    const iss = `${backendOrigin}/v/${fhir_version}/fhir`;
+    const iss = ENV.PROXY_FHIR_REQUESTS
+        ? `${backendOrigin}/v/${fhir_version}/fhir`
+        : (ENV as any)[`FHIR_SERVER_${fhir_version.toUpperCase()}`];
 
     // The URL to launch the sample app
     let sampleLaunchUrl = new URL(


### PR DESCRIPTION
## Overview

- `AuthorizeHandler` now verifies `aud` claim against the FHIR server URL instead of the launcher URL when `PROXY_FHIR_REQUESTS = "false"`

## How it was tested

- Ran launcher locally and did a quick sanity check
- Could not test aud verification without proxy when running locally

## Checklist

- [x] The title contains a short meaningful summary
- [ ] I have added a link to this PR in the Jira issue
- [ ] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)